### PR TITLE
Fix #17 (--scoreOnly command line option)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,6 +246,8 @@ int main(int argc, char *argv[]) {
       res.rotor[0] = 1.0;
       bestScore = getScore(uo.whichScore, res.overlap, refVolume.overlap,
                            dbVolume.overlap);
+      bestSolution.refAtomVolume = refVolume.overlap;
+      updateSolutionInfo(bestSolution, res, bestScore, dbVolume);
     } else {
       initOrientation(dbVolume);
 


### PR DESCRIPTION
Fix issue  #17
When shape-it is run from the command line with the --scoreOnly option, the bestSolution object which stores the results was never updated, which caused 0 and nan values in the scores file.